### PR TITLE
Allow account names up to 32 characters

### DIFF
--- a/VikunjaCore/VikunjaConfig.swift
+++ b/VikunjaCore/VikunjaConfig.swift
@@ -20,7 +20,7 @@ enum VikunjaConfig {
     static let appGroupSuite = "group.net.angstreich.VikunjaWidgetApp"
     static let vikunjaCloudHost = "https://app.vikunja.cloud"
     static let maxAccounts = 5
-    static let maxAccountNameLength = 10
+    static let maxAccountNameLength = 32
 
     private static var defaults: UserDefaults? { UserDefaults(suiteName: appGroupSuite) }
 


### PR DESCRIPTION
## Summary

- Increase the shared account-name limit from 10 to 32 characters
- Apply the 32-character limit consistently to onboarding, account editing, and hostname-derived migration names

Fixes #3

## Verification

- `swiftc -parse VikunjaCore/VikunjaConfig.swift`
- `git diff --check`