### PR TITLE
Fix task rescheduling after Vikunja v2 validation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ VeyrnShots.*
 *.xcuserstate
 xcuserdata/
 DerivedData/
+build/
 *.ipa
 *.dSYM.zip
 *.dSYM

--- a/VikunjaCore/VikunjaAPI.swift
+++ b/VikunjaCore/VikunjaAPI.swift
@@ -511,15 +511,45 @@ enum VikunjaAPI {
     /// The headline v2 win: merge-patch means only the changed fields are ever
     /// sent, so omitted fields structurally can't be clobbered — no pre-fetch
     /// needed for the patch itself (V-2). This eliminates the 2.7.1 bug class
-    /// on v2 servers. No v1 fallback on failure (mutations route by flag).
+    /// on v2 servers. A definitive 422 falls back to the existing v1 path;
+    /// ambiguous transport failures still never replay a mutation.
     static func updateTask(id: Int, update: TaskUpdate) async throws -> VikunjaTask {
         if supportsAPIv2 {
-            try await updateTaskV2(id: id, update: update)
-            // Re-fetch so the returned task includes updated labels — same
-            // contract as v1 below.
-            return try await fetchTask(id: id)
+            return try await performV2TaskUpdate(
+                updateV2: { try await updateTaskV2(id: id, update: update) },
+                fetchUpdated: { try await fetchTask(id: id) },
+                updateV1: { try await updateTaskV1(id: id, update: update) }
+            )
         }
         return try await updateTaskV1(id: id, update: update)
+    }
+
+    struct V2TaskPatchRejected: Error {}
+
+    static func performV2TaskUpdate<T>(
+        updateV2: () async throws -> Void,
+        fetchUpdated: () async throws -> T,
+        updateV1: () async throws -> T
+    ) async throws -> T {
+        do {
+            try await updateV2()
+        } catch {
+            guard error is V2TaskPatchRejected else { throw error }
+            DiagnosticLog.warn(
+                "v2 task update returned 422; falling back to v1"
+            )
+            return try await updateV1()
+        }
+        return try await fetchUpdated()
+    }
+
+    /// Vikunja 2.4.0 can reject AutoPatch's internally merged task when a
+    /// read-only response field does not match the PUT schema. A 422 proves
+    /// the PATCH was rejected before mutation, so retrying the existing v1
+    /// full-update path cannot double-apply the edit.
+    static func v2TaskPatchIsUnprocessable(_ error: Error) -> Bool {
+        guard let apiError = error as? APIError else { return false }
+        return apiError.statusCode == 422
     }
 
     private static func updateTaskV2(id: Int, update: TaskUpdate) async throws {
@@ -560,7 +590,14 @@ enum VikunjaAPI {
         }
 
         if !body.isEmpty {
-            try await patchV2("/tasks/\(id)", body: body)
+            do {
+                try await patchV2("/tasks/\(id)", body: body)
+            } catch {
+                if v2TaskPatchIsUnprocessable(error) {
+                    throw V2TaskPatchRejected()
+                }
+                throw error
+            }
         }
 
         if let labelIds = update.labelIds {

--- a/VikunjaCore/VikunjaAPI.swift
+++ b/VikunjaCore/VikunjaAPI.swift
@@ -776,9 +776,23 @@ enum VikunjaAPI {
     /// output: merge-patch needs an *explicit* `NSNull()` for a clear and an
     /// *absent* key for "no change", a distinction `Codable` can't express.
     private static func patchV2(_ path: String, body: [String: Any]) async throws {
-        let data = try JSONSerialization.data(withJSONObject: body)
-        let request = makeRequest(path, method: "PATCH", body: data, base: v2BaseURL)
+        let request = try makeMergePatchRequest(path, body: body)
         _ = try await send(request, acceptingNotModified: true)
+    }
+
+    static func makeMergePatchRequest(
+        _ path: String,
+        body: [String: Any],
+        base: String? = nil
+    ) throws -> URLRequest {
+        let data = try JSONSerialization.data(withJSONObject: body)
+        return makeRequest(
+            path,
+            method: "PATCH",
+            body: data,
+            base: base ?? v2BaseURL,
+            contentType: "application/merge-patch+json"
+        )
     }
 
     private static func putV2(_ path: String, body: Data) async throws {
@@ -821,13 +835,19 @@ enum VikunjaAPI {
         return result.items ?? []
     }
 
-    private static func makeRequest(_ path: String, method: String = "GET", body: Data? = nil, base: String? = nil) -> URLRequest {
+    private static func makeRequest(
+        _ path: String,
+        method: String = "GET",
+        body: Data? = nil,
+        base: String? = nil,
+        contentType: String = "application/json"
+    ) -> URLRequest {
         let baseURL = base ?? self.baseURL
         var request = URLRequest(url: URL(string: "\(baseURL)\(path)")!, timeoutInterval: 20)
         request.httpMethod = method
         request.setValue("Bearer \(VikunjaConfig.apiToken)", forHTTPHeaderField: "Authorization")
         if let body {
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
             request.httpBody = body
         }
         return request

--- a/VikunjaWidget.xcodeproj/project.pbxproj
+++ b/VikunjaWidget.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		95081F050067C8886AB0A59D /* ColorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1254289BB5BBCBD170DCACE /* ColorUtils.swift */; };
 		950BD0C66AAC8B38D8A50D71 /* WidgetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9646D37E52F94B16B7960FD4 /* WidgetCache.swift */; };
 		95ACD4AB52AF0FEF6716FB2C /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A88F453140ABF753FB449C /* DiagnosticLog.swift */; };
+		96A9B902EDD23A7FBED8BE23 /* VikunjaAPIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF72BF558B5C3997B1AFDF9D /* VikunjaAPIRequestTests.swift */; };
 		9760739F1921EFE07139E83C /* UndoCompleteTaskIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E12C5D7A535480216299E3 /* UndoCompleteTaskIntent.swift */; };
 		97AAC28FA52B79FBC01E7E6B /* TaskMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775BB9BC7FF3DF58DFDDBD96 /* TaskMerger.swift */; };
 		99248E0B0E92BD4F33A7E065 /* BackgroundRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DFECBCB1BD52DDACF60742 /* BackgroundRefresh.swift */; };
@@ -227,6 +228,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1F02847C6D308FF7D45A21A7;
 			remoteInfo = VikunjaWidgetExtension;
+		};
+		10D2401A149522024CBE871A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F0707309F68A7FEA5FBF037E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1F53CB9A95EE058BF7773B4B;
+			remoteInfo = VikunjaWidgetApp;
 		};
 		24C6544BA2D2991A0B01D091 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -365,6 +373,7 @@
 		AA24B83963A30DBD2EBED4CA /* WatchSessionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSessionProvider.swift; sourceTree = "<group>"; };
 		AC0EC5DA80C84EAC14606DF3 /* TaskRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskRowView.swift; sourceTree = "<group>"; };
 		AE1E2473B28773FB31C83C53 /* RichTextToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichTextToolbar.swift; sourceTree = "<group>"; };
+		B14D61FAE50901A5B2408AB3 /* VikunjaWidgetAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VikunjaWidgetAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B16569443230F1F6C58E4DD9 /* ReminderStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderStore.swift; sourceTree = "<group>"; };
 		B189E2189A5C4A68E826A0BC /* VikunjaWidgetApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VikunjaWidgetApp.swift; sourceTree = "<group>"; };
 		B3BB9C870B4EF39EC432A03D /* ProjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectView.swift; sourceTree = "<group>"; };
@@ -374,6 +383,7 @@
 		BBB0B0D0A0BF988D3D00D46A /* WatchWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWidgetProvider.swift; sourceTree = "<group>"; };
 		BDB2CBC26BADD19ED549207B /* VikunjaWidgetApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VikunjaWidgetApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDF5D7B53205EC9A9D91FC36 /* BugReportMail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugReportMail.swift; sourceTree = "<group>"; };
+		BF72BF558B5C3997B1AFDF9D /* VikunjaAPIRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VikunjaAPIRequestTests.swift; sourceTree = "<group>"; };
 		C0FF9B209536157736A98A9B /* TokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenStore.swift; sourceTree = "<group>"; };
 		C1254289BB5BBCBD170DCACE /* ColorUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorUtils.swift; sourceTree = "<group>"; };
 		C1938B254B547B170A850D02 /* WatchWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchWidget.swift; sourceTree = "<group>"; };
@@ -469,6 +479,7 @@
 				BCCB1884FA56BEC5635FF7C7 /* VikunjaCore */,
 				1FFE98D62C37DE8550B1EE9A /* VikunjaWidget */,
 				27A31AAA3E9CBEDF1D336C73 /* VikunjaWidgetApp */,
+				B6D095907B73871B55F4CBE6 /* VikunjaWidgetAppTests */,
 				8C5FFA15540FB600A0E22245 /* VikunjaWidgetExtension */,
 				F76B21BFF3DFB7E42686F231 /* VikunjaWidgetWatch */,
 				3ECC6F58DDDA21CACB54679C /* VikunjaWidgetWatchExtension */,
@@ -554,6 +565,7 @@
 			children = (
 				BDB2CBC26BADD19ED549207B /* VikunjaWidgetApp.app */,
 				94A79F734B4FA3F1B7F71059 /* VikunjaWidgetAppIOS.app */,
+				B14D61FAE50901A5B2408AB3 /* VikunjaWidgetAppTests.xctest */,
 				30D8862B6CFF3E3E06B26ACA /* VikunjaWidgetExtension.appex */,
 				31047F6BFB8F2F00A7627426 /* VikunjaWidgetExtensionIOS.appex */,
 				79B09FCA9032E9C475309927 /* VikunjaWidgetWatch.app */,
@@ -580,6 +592,14 @@
 				5D3D5CA4D4C4BC81BDF1AC44 /* WidgetPageState.swift */,
 			);
 			path = VikunjaWidgetExtension;
+			sourceTree = "<group>";
+		};
+		B6D095907B73871B55F4CBE6 /* VikunjaWidgetAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				BF72BF558B5C3997B1AFDF9D /* VikunjaAPIRequestTests.swift */,
+			);
+			path = VikunjaWidgetAppTests;
 			sourceTree = "<group>";
 		};
 		BCCB1884FA56BEC5635FF7C7 /* VikunjaCore */ = {
@@ -745,6 +765,24 @@
 			productReference = 79B09FCA9032E9C475309927 /* VikunjaWidgetWatch.app */;
 			productType = "com.apple.product-type.application";
 		};
+		95560EDEFCF98E06593EAC53 /* VikunjaWidgetAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5F4D19496A6BEE8FE02911AB /* Build configuration list for PBXNativeTarget "VikunjaWidgetAppTests" */;
+			buildPhases = (
+				1F9893B7FED8044328D34F61 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1920093128342BE77C4FA145 /* PBXTargetDependency */,
+			);
+			name = VikunjaWidgetAppTests;
+			packageProductDependencies = (
+			);
+			productName = VikunjaWidgetAppTests;
+			productReference = B14D61FAE50901A5B2408AB3 /* VikunjaWidgetAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		A0698B744356C9C9BF163D6D /* VikunjaWidgetExtensionIOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 03795ED8FDF1D28E1A9B41C9 /* Build configuration list for PBXNativeTarget "VikunjaWidgetExtensionIOS" */;
@@ -793,6 +831,9 @@
 						DevelopmentTeam = VEB4GCTC3B;
 						ProvisioningStyle = Automatic;
 					};
+					95560EDEFCF98E06593EAC53 = {
+						ProvisioningStyle = Automatic;
+					};
 					A0698B744356C9C9BF163D6D = {
 						DevelopmentTeam = VEB4GCTC3B;
 						ProvisioningStyle = Automatic;
@@ -816,6 +857,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				95560EDEFCF98E06593EAC53 /* VikunjaWidgetAppTests */,
 				1F53CB9A95EE058BF7773B4B /* VikunjaWidgetApp */,
 				1F02847C6D308FF7D45A21A7 /* VikunjaWidgetExtension */,
 				5089A31E80CF606C44D1424F /* VikunjaWidgetAppIOS */,
@@ -927,6 +969,14 @@
 				7D23D0A203B4397E740C4534 /* VikunjaWidgetApp.swift in Sources */,
 				8539E404CFA5AED9E7EE80C6 /* WatchSessionProvider.swift in Sources */,
 				426140361E8189D111CEC188 /* WidgetCache.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F9893B7FED8044328D34F61 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96A9B902EDD23A7FBED8BE23 /* VikunjaAPIRequestTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1109,6 +1159,11 @@
 			target = 0F7E0CF84A988BC300A48423 /* VikunjaWidgetWatchExtension */;
 			targetProxy = 24C6544BA2D2991A0B01D091 /* PBXContainerItemProxy */;
 		};
+		1920093128342BE77C4FA145 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1F53CB9A95EE058BF7773B4B /* VikunjaWidgetApp */;
+			targetProxy = 10D2401A149522024CBE871A /* PBXContainerItemProxy */;
+		};
 		3A482F59F63B77FB7F175B05 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 93A8A8EF93CAD82843BD97D9 /* VikunjaWidgetWatch */;
@@ -1127,6 +1182,23 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0976B156ABA036445D680718 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.angstreich.VikunjaWidgetAppTests;
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Veyrn.app/Contents/MacOS/Veyrn";
+			};
+			name = Debug;
+		};
 		10CB846D00092EEDE03CCF35 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1280,6 +1352,23 @@
 				WATCHOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
+		};
+		4B194518A3870728191C9C74 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = net.angstreich.VikunjaWidgetAppTests;
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Veyrn.app/Contents/MacOS/Veyrn";
+			};
+			name = Release;
 		};
 		517D5F063D290ABF7B050B0B /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1521,6 +1610,15 @@
 			buildConfigurations = (
 				96B15628B226E582B92AD9D3 /* Debug */,
 				69021C3734E8C262088C6202 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		5F4D19496A6BEE8FE02911AB /* Build configuration list for PBXNativeTarget "VikunjaWidgetAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0976B156ABA036445D680718 /* Debug */,
+				4B194518A3870728191C9C74 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/VikunjaWidget.xcodeproj/xcshareddata/xcschemes/VikunjaWidgetApp.xcscheme
+++ b/VikunjaWidget.xcodeproj/xcshareddata/xcschemes/VikunjaWidgetApp.xcscheme
@@ -51,6 +51,17 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "95560EDEFCF98E06593EAC53"
+               BuildableName = "VikunjaWidgetAppTests.xctest"
+               BlueprintName = "VikunjaWidgetAppTests"
+               ReferencedContainer = "container:VikunjaWidget.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/VikunjaWidgetAppTests/VikunjaAPIRequestTests.swift
+++ b/VikunjaWidgetAppTests/VikunjaAPIRequestTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import Veyrn
+
+final class VikunjaAPIRequestTests: XCTestCase {
+    func testMergePatchRequestUsesMergePatchContentType() throws {
+        let request = try VikunjaAPI.makeMergePatchRequest(
+            "/tasks/42",
+            body: ["due_date": "2026-08-25T01:00:00Z"],
+            base: "https://vikunja.example/api/v2"
+        )
+
+        XCTAssertEqual(request.httpMethod, "PATCH")
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Content-Type"),
+            "application/merge-patch+json"
+        )
+    }
+}

--- a/VikunjaWidgetAppTests/VikunjaAPIRequestTests.swift
+++ b/VikunjaWidgetAppTests/VikunjaAPIRequestTests.swift
@@ -2,6 +2,80 @@ import XCTest
 @testable import Veyrn
 
 final class VikunjaAPIRequestTests: XCTestCase {
+    func testUnprocessableV2TaskPatchIsEligibleForFallback() {
+        XCTAssertTrue(
+            VikunjaAPI.v2TaskPatchIsUnprocessable(
+                VikunjaAPI.APIError.badStatus(422)
+            )
+        )
+        XCTAssertFalse(
+            VikunjaAPI.v2TaskPatchIsUnprocessable(
+                VikunjaAPI.APIError.badStatus(401)
+            )
+        )
+    }
+
+    func testRejectedV2TaskPatchInvokesV1FallbackOnce() async throws {
+        var fallbackCount = 0
+        var fetchCount = 0
+
+        let result: String = try await VikunjaAPI.performV2TaskUpdate(
+            updateV2: { throw VikunjaAPI.V2TaskPatchRejected() },
+            fetchUpdated: {
+                fetchCount += 1
+                return "v2"
+            },
+            updateV1: {
+                fallbackCount += 1
+                return "v1"
+            }
+        )
+
+        XCTAssertEqual(result, "v1")
+        XCTAssertEqual(fallbackCount, 1)
+        XCTAssertEqual(fetchCount, 0)
+    }
+
+    func testLaterV2Task422DoesNotInvokeV1Fallback() async {
+        var fallbackCount = 0
+
+        do {
+            let _: String = try await VikunjaAPI.performV2TaskUpdate(
+                updateV2: { throw VikunjaAPI.APIError.badStatus(422) },
+                fetchUpdated: { "v2" },
+                updateV1: {
+                    fallbackCount += 1
+                    return "v1"
+                }
+            )
+            XCTFail("Expected the later v2 error to propagate")
+        } catch {
+            XCTAssertEqual((error as? VikunjaAPI.APIError)?.statusCode, 422)
+        }
+
+        XCTAssertEqual(fallbackCount, 0)
+    }
+
+    func testPostUpdateFetch422DoesNotInvokeV1Fallback() async {
+        var fallbackCount = 0
+
+        do {
+            let _: String = try await VikunjaAPI.performV2TaskUpdate(
+                updateV2: {},
+                fetchUpdated: { throw VikunjaAPI.APIError.badStatus(422) },
+                updateV1: {
+                    fallbackCount += 1
+                    return "v1"
+                }
+            )
+            XCTFail("Expected the fetch error to propagate")
+        } catch {
+            XCTAssertEqual((error as? VikunjaAPI.APIError)?.statusCode, 422)
+        }
+
+        XCTAssertEqual(fallbackCount, 0)
+    }
+
     func testMergePatchRequestUsesMergePatchContentType() throws {
         let request = try VikunjaAPI.makeMergePatchRequest(
             "/tasks/42",

--- a/project.yml
+++ b/project.yml
@@ -38,6 +38,8 @@ schemes:
       config: Debug
     test:
       config: Debug
+      targets:
+        - VikunjaWidgetAppTests
     profile:
       config: Release
     analyze:
@@ -73,6 +75,19 @@ schemes:
 
 targets:
   # ── macOS ────────────────────────────────────────────────────────────────
+
+  VikunjaWidgetAppTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: VikunjaWidgetAppTests
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: net.angstreich.VikunjaWidgetAppTests
+      MACOSX_DEPLOYMENT_TARGET: "14.0"
+      TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Veyrn.app/Contents/MacOS/Veyrn"
+      BUNDLE_LOADER: "$(TEST_HOST)"
+    dependencies:
+      - target: VikunjaWidgetApp
 
   VikunjaWidgetApp:
     type: application


### PR DESCRIPTION
Summary:
- Keep the standards-correct JSON Merge Patch media type for Vikunja v2 PATCH requests.
- Fall back to the existing v1 full-task update only when the initial v2 task PATCH definitively returns 422.
- Prevent later label-sync or refresh failures from replaying a mutation.
- Add behavioral regression tests for the fallback and no-replay boundaries.

Root cause:
- A live reschedule of task 217 reached Vikunja 2.4.0 and returned HTTP 422.
- The response was: validation failed at body.subscription.entity, expected integer, value task.
- Vikunja AutoPatch merges the GET response into an internal PUT. The read-only subscription response shape fails that PUT schema validation.
- Vikunja 2.4.0 also accepts application/json as merge patch input, so the header mismatch was not the cause of the observed 422.

Verification:
- Focused Vikunja API tests: 5 passed.
- The changed shared API code compiled for the iOS simulator through VikunjaWidgetExtensionIOS.
- The live 422 reproduction was verified non-mutating before implementation.
- Pre-push secret and PII scan passed.